### PR TITLE
Command-line arguments and interactive prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,19 +8,17 @@ Still to do:
 
 - Include logic for '.' when unescaped
 - Include logic for dealing with flags
-- Turn this into a program that can take command line arguments.  *facepalm*
 
 Requirements to run locally:
-- Node installed globally 
+- Node installed globally
 - yarn installed globally (only if running tests)
 
 Instructions to run program currently:
 
 - Clone repo
 - cd into folder
-- to see what regular expression program is testing against, refer to the last line in index.js
-- to change it to a different regular expression, change the regular expression being passed to the function in index.js
-- `node index.js`
+- Run `node index.js` and type a regular expression at the prompt, or you may
+  pass it as an argument
 
 To run tests:
 - `yarn` to install dependencies

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const handleLooks = require("./components/looks.js");
 const InvalidRegularExpression = require("./components/InvalidRegularExpression.js");
 const { initialize, getFlags } = require("./components/setup.js");
 const { parseBackslash } = require("./components/backSlash.js");
+const readline = require('readline');
 
 function parseRegex(regex) {
   let { regexString, flags } = initialize(regex);
@@ -85,4 +86,23 @@ function parseRegex(regex) {
   return `${returnString.start} ${returnString.middle} ${returnString.end}`;
 }
 
-console.log(parseRegex(/\b\w*[^s\W]a\b/gim));
+if (require.main == module) {
+  if (process.argv.length >= 3) {
+    // Take input from argument
+    console.log(parseRegex(process.argv[2]));
+  } else {
+    // Interactive prompt
+    const rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout
+    });
+
+    function promptRegex() {
+      rl.question("> ", regex => {
+        console.log(parseRegex(regex));
+        promptRegex();
+      });
+    }
+    promptRegex();
+  }
+}


### PR DESCRIPTION
Take a regular expression as a command-line argument:

```sh
node index.js <regex>
```

Alternatively, if no argument is given then the program will run in an interactive mode, allowing the user to type expressions at a shell-like prompt.